### PR TITLE
Fix build error 'malloc.h' file not found

### DIFF
--- a/elf2dfuse.c
+++ b/elf2dfuse.c
@@ -23,7 +23,7 @@
 
 #include <stdio.h>
 #include <stdint.h>
-#include <malloc.h>
+#include <stdlib.h>
 #include <string.h>
 
 #define USB_VENDOR_ID  0x0483


### PR DESCRIPTION
Replace linux specific file with generic file for malloc() macro